### PR TITLE
Remove wrappers

### DIFF
--- a/cbf2jpeg.py
+++ b/cbf2jpeg.py
@@ -27,7 +27,7 @@ cbf_dir = os.path.join(directory, 'cbf')
 CBF_conversion_pattern = os.path.join(cbf_dir, f'{file_prefix}_')
 JPEG_conversion_pattern = os.path.join(full_jpeg_directory, f'{file_prefix}_')
 
-adxv_comm = os.path.join(os.environ["PROJDIR"], getBlConfig('adxvComm', beamline))
+adxv_comm = getBlConfig('adxvComm', beamline)
 comm_s = f'{adxv_comm} -sa {CBF_conversion_pattern}000001.cbf {JPEG_conversion_pattern}0001.jpg'
 os.system(comm_s)
 comm_s = f'convert {JPEG_conversion_pattern}0001.jpg -resize 10% {JPEG_conversion_pattern}0001.thumb.jpg'

--- a/cbf2jpeg.sh
+++ b/cbf2jpeg.sh
@@ -1,7 +1,6 @@
 #$/bin/bash
 export PROJDIR=/GPFS/CENTRAL/xf17id1/skinnerProjectsBackup/
 export PYTHONPATH=${PROJDIR}/lsdc:$PYTHONPATH
-export WRAPPERSDIR=${PROJDIR}/wrappers/
 export MONGODB_HOST='xf17id1-lsdcmongo.nsls2.bnl.local'
 export BEAMLINE_ID='fmx' # TODO required to keep daq_utils happy
 /opt/conda_envs/mx-processing-env/bin/python ${PROJDIR}/mx-processing/cbf2jpeg.py "$@"

--- a/dials_spotfind.sh
+++ b/dials_spotfind.sh
@@ -1,7 +1,6 @@
 #$/bin/bash
 export PROJDIR=/GPFS/CENTRAL/xf17id1/skinnerProjectsBackup
 export PYTHONPATH=${PROJDIR}/lsdc:$PYTHONPATH
-export WRAPPERSDIR=${PROJDIR}/wrappers/
 export MONGODB_HOST='xf17id1-lsdcmongo.nsls2.bnl.local'
 export BEAMLINE_ID='fmx' # TODO required to keep daq_utils happy
 /opt/conda_envs/mx-processing-env/bin/python ${PROJDIR}/mx-processing/dials_spotfind.py "$@"

--- a/dimple.py
+++ b/dimple.py
@@ -28,7 +28,7 @@ directory = result["request_obj"]["directory"]
 base_directory = result["request_obj"]["basePath"]
 dimple_running_dir = os.path.join(directory, 'dimpleOutput')
 fastdp_running_dir = os.path.join(directory, 'fastDPOutput')
-dimple_comm = f'{getBlConfig("dimpleComm", beamline)}'
+dimple_comm = getBlConfig("dimpleComm", beamline)
 
 os.makedirs(dimple_running_dir, exist_ok=True)
 os.chdir(dimple_running_dir)

--- a/dimple.sh
+++ b/dimple.sh
@@ -1,7 +1,6 @@
 #$/bin/bash
 export PROJDIR=/GPFS/CENTRAL/xf17id1/skinnerProjectsBackup
 export PYTHONPATH=${PROJDIR}/lsdc:$PYTHONPATH
-export WRAPPERSDIR=${PROJDIR}/wrappers/
 export MONGODB_HOST='xf17id1-lsdcmongo.nsls2.bnl.local'
 export BEAMLINE_ID='fmx' # TODO required to keep daq_utils happy
 /opt/conda_envs/mx-processing-env/bin/python ${PROJDIR}/mx-processing/dimple.py "$@"

--- a/dozor.py
+++ b/dozor.py
@@ -19,7 +19,7 @@ else:
 request = db_lib.getRequestByID(collection_id, active_only)
 directory = request["request_obj"]["directory"]
 dozor_dir = os.path.join(directory, 'dozor', f'row_{row_index}')
-dozor_comm = "/usr/local/crys-local/dozor-10Aug2020/dozor"
+dozor_comm = "dozor"
 comm_s = f"cd {dozor_dir}; {dozor_comm} -w -bin 1 h5_row_{row_index}.dat"
 print(f'dozor call: {comm_s}')
 os.system(comm_s)

--- a/dozor.sh
+++ b/dozor.sh
@@ -1,7 +1,6 @@
 #$/bin/bash
 export PROJDIR=/GPFS/CENTRAL/xf17id1/skinnerProjectsBackup
 export PYTHONPATH=${PROJDIR}/lsdc:$PYTHONPATH
-export WRAPPERSDIR=${PROJDIR}/wrappers/
 export MONGODB_HOST='xf17id1-lsdcmongo.nsls2.bnl.local'
 export BEAMLINE_ID='fmx' # TODO required to keep daq_utils happy
 /opt/conda_envs/mx-processing-env/bin/python ${PROJDIR}/mx-processing/dozor.py "$@"

--- a/edna.py
+++ b/edna.py
@@ -12,10 +12,7 @@ else:
 result = db_lib.getRequestByID(collection_id, active_only)
 transmission_percent = float(transmission_percent)
 beamline = result['request_obj']['beamline']
-if beamline in ('fmx', 'amx'):
-    ednaWrap = f'ednaWrap_{beamline}'
-else:
     raise Exception('Unknown EDNA host')
-comm_s = f'/bin/bash -c \"source {os.environ["WRAPPERSDIR"]}/{ednaWrap};cd {dna_directory};{os.environ["LSDCHOME"]}/runEdna.py {cbf1} {cbf2} {transmission_percent} {flux} {xbeam_size} {ybeam_size} {collection_id} {beamline}\"'
+comm_s = f'cd {dna_directory};{os.environ["LSDCHOME"]}/runEdna.py {cbf1} {cbf2} {transmission_percent} {flux} {xbeam_size} {ybeam_size} {collection_id} {beamline}'
 print(f'EDNA call: {comm_s}')
 os.system(comm_s)

--- a/edna.py
+++ b/edna.py
@@ -10,9 +10,10 @@ else:
     active_only = True
 
 result = db_lib.getRequestByID(collection_id, active_only)
-transmission_percent = float(transmission_percent)
 beamline = result['request_obj']['beamline']
-    raise Exception('Unknown EDNA host')
+os.environ['EDNA_SITE'] = f"NSLS2_{beamline.upper()}"
+os.environ['LD_LIBRARY_PATH'] += ':/usr/lib64/raddose-v2-20-05-09'  # TODO verify raddose location in RPM. verify correct method to use this key in python
+transmission_percent = float(transmission_percent)
 comm_s = f'cd {dna_directory};{os.environ["LSDCHOME"]}/runEdna.py {cbf1} {cbf2} {transmission_percent} {flux} {xbeam_size} {ybeam_size} {collection_id} {beamline}'
 print(f'EDNA call: {comm_s}')
 os.system(comm_s)

--- a/edna.sh
+++ b/edna.sh
@@ -2,7 +2,6 @@
 export PROJDIR=/GPFS/CENTRAL/xf17id1/skinnerProjectsBackup
 export LSDCHOME=${PROJDIR}/lsdc
 export PYTHONPATH=${PROJDIR}/lsdc:$PYTHONPATH
-export WRAPPERSDIR=${PROJDIR}/wrappers/
 export MONGODB_HOST='xf17id1-lsdcmongo.nsls2.bnl.local'
 export BEAMLINE_ID='fmx' # TODO required to keep daq_utils happy
 /opt/conda_envs/mx-processing-env/bin/python ${PROJDIR}/mx-processing/edna.py "$@"

--- a/eiger2cbf.sh
+++ b/eiger2cbf.sh
@@ -1,7 +1,6 @@
 #$/bin/bash
 export PROJDIR=/GPFS/CENTRAL/xf17id1/skinnerProjectsBackup
 export PYTHONPATH=${PROJDIR}/lsdc:$PYTHONPATH
-export WRAPPERSDIR=${PROJDIR}/wrappers/
 export MONGODB_HOST='xf17id1-lsdcmongo.nsls2.bnl.local'
 export BEAMLINE_ID='fmx' # TODO required to keep daq_utils happy
 /opt/conda_envs/mx-processing-env/bin/python ${PROJDIR}/mx-processing/eiger2cbf.py "$@"

--- a/fast_dp.py
+++ b/fast_dp.py
@@ -17,7 +17,7 @@ running_dir = os.path.join(directory, 'fastDPOutput')
 file_prefix = result["request_obj"]["file_prefix"]
 prefix_long = os.path.join(directory, f'{file_prefix}_{seq_num}')
 hdf_file_pattern = f'{prefix_long}_master.h5'
-fast_dp_comm = f'{getBlConfig("fastdpComm", beamline)} {hdf_file_pattern}'
-comm_s = f"cd {running_dir};{fast_dp_comm}"
+fast_dp_comm = getBlConfig("fastdpComm", beamline)
+comm_s = f"cd {running_dir};{fast_dp_comm} {hdf_file_pattern}"
 print(f'Fast DP invocation: {comm_s}')
 os.system(comm_s)

--- a/fast_dp.py
+++ b/fast_dp.py
@@ -17,7 +17,7 @@ running_dir = os.path.join(directory, 'fastDPOutput')
 file_prefix = result["request_obj"]["file_prefix"]
 prefix_long = os.path.join(directory, f'{file_prefix}_{seq_num}')
 hdf_file_pattern = f'{prefix_long}_master.h5'
-fast_dp_comm = f'/bin/bash -c \"source {os.environ["WRAPPERSDIR"]}/fastDPWrap2;{getBlConfig("fastdpComm", beamline)} {hdf_file_pattern}\"'
+fast_dp_comm = f'{getBlConfig("fastdpComm", beamline)} {hdf_file_pattern}'
 comm_s = f"cd {running_dir};{fast_dp_comm}"
 print(f'Fast DP invocation: {comm_s}')
 os.system(comm_s)

--- a/fast_dp.sh
+++ b/fast_dp.sh
@@ -1,7 +1,6 @@
 #$/bin/bash
 export PROJDIR=/GPFS/CENTRAL/xf17id1/skinnerProjectsBackup
 export PYTHONPATH=${PROJDIR}/lsdc:$PYTHONPATH
-export WRAPPERSDIR=${PROJDIR}/wrappers/
 export MONGODB_HOST='xf17id1-lsdcmongo.nsls2.bnl.local'
 export BEAMLINE_ID='fmx' # TODO required to keep daq_utils happy
 /opt/conda_envs/mx-processing-env/bin/python ${PROJDIR}/mx-processing/fast_dp.py "$@"

--- a/xia2.sh
+++ b/xia2.sh
@@ -1,7 +1,6 @@
 #$/bin/bash
 export PROJDIR=/GPFS/CENTRAL/xf17id1/skinnerProjectsBackup
 export PYTHONPATH=${PROJDIR}/lsdc:$PYTHONPATH
-export WRAPPERSDIR=${PROJDIR}/wrappers/
 export MONGODB_HOST='xf17id1-lsdcmongo.nsls2.bnl.local'
 export BEAMLINE_ID='fmx' # TODO required to keep daq_utils happy
 /opt/conda_envs/mx-processing-env/bin/python ${PROJDIR}/mx-processing/runXia2.py "$@"


### PR DESCRIPTION
NOTE: will be undergoing testing

Part of AMX/FMX processing cluster upgrade work that includes installation streamlining

As processing programs and associated libraries are now installed via RPMs into standard locations on the new RHEL 8 computing nodes, there is no need for elaborate environment setup wrappers and nonstandard locations of files (within /usr/local/crys-local).